### PR TITLE
Do not use project in file path.

### DIFF
--- a/lib/redmine_objectstorage/attachment_patch.rb
+++ b/lib/redmine_objectstorage/attachment_patch.rb
@@ -2,21 +2,21 @@ require "fog"
 
 module RedmineObjectStorage
   module AttachmentPatch
-    
+
     def self.included(base) # :nodoc:
       base.extend(ClassMethods)
       base.send(:include, InstanceMethods)
 
       base.class_eval do
         unloadable
-        
+
         cattr_accessor :context_obj, :objectstorage_bucket_instance, :__objectstorage_config
 
         after_validation :save_to_objectstorage
         before_destroy   :delete_from_objectstorage
 
         def readable?
-          !!Attachment.objectstorage_bucket.get(self.objectstorage_path) rescue false
+          !!Attachment.objectstorage_bucket.get(self.objectstorage_filename) rescue false
         end
       end
     end
@@ -25,7 +25,7 @@ module RedmineObjectStorage
       def set_context(context)
         @@context_obj = context
       end
-      
+
       def get_context
         @@context_obj
       end
@@ -51,10 +51,10 @@ module RedmineObjectStorage
         end
         @@objectstorage_bucket_instance
       end
-      
-      def objectstorage_absolute_path(filename, project_id)
+
+      def objectstorage_absolute_path(filename)
         ts = DateTime.now.strftime("%y%m%d%H%M%S")
-        [project_id, ts, filename].compact.join("/")
+        [ts, filename].compact.join("/")
       end
     end
 
@@ -68,38 +68,26 @@ module RedmineObjectStorage
         self.disk_filename.blank? ? filename : self.disk_filename
       end
 
-      # path on objectstorage to the file, defaulting the instance's disk_filename
-      def objectstorage_path(fn = objectstorage_filename)#, ctx = nil, pid = nil)
-        context = self.container || self.class.get_context
-        project = context.is_a?(Hash) ? Project.find(context[:project]) : context.project
-        ctx = context.is_a?(Hash) ? context[:class] : context.class.name
-        # XXX s/WikiPage/Wiki
-        ctx = "Wiki" if ctx == "WikiPage"
-        pid = project.identifier
-        
-        [pid, fn].compact.join("/")
-      end
-
       def save_to_objectstorage
         if @temp_file && !@temp_file.empty?
           logger.debug "[redmine_objectstorage_attachments] Uploading #{objectstorage_filename}"
 
           file = Attachment.objectstorage_bucket.files.create(
-            key: objectstorage_path, 
+            key: objectstorage_filename,
             body: @temp_file.is_a?(String) ? @temp_file : @temp_file.read
           )
-          
+
           self.digest = file.etag
         end
 
-        # set the temp file to nil so the model's original after_save block 
+        # set the temp file to nil so the model's original after_save block
         # skips writing to the filesystem
         @temp_file = nil
       end
 
       def delete_from_objectstorage
         logger.debug "[redmine_objectstorage_attachments] Deleting #{objectstorage_filename}"
-        Attachment.objectstorage_bucket.files.get(objectstorage_path(objectstorage_filename)).destroy
+        Attachment.objectstorage_bucket.files.get(objectstorage_filename).destroy
       end
     end
   end

--- a/lib/redmine_objectstorage/attachments_controller_patch.rb
+++ b/lib/redmine_objectstorage/attachments_controller_patch.rb
@@ -1,6 +1,6 @@
 module RedmineObjectStorage
   module AttachmentsControllerPatch
-    
+
     def self.included(base) # :nodoc:
       base.class_eval do
         unloadable
@@ -11,7 +11,7 @@ module RedmineObjectStorage
 
     def redirect_to_objectstorage
       skip_redirection = false
-      
+
       if @attachment.nil?
         # Since we uploads occur prior to an actual record being created,
         # the context needs to be parsed from the url.
@@ -27,7 +27,7 @@ module RedmineObjectStorage
         # For attachments in the "File" area, we want to identify
         # as a "Project" since there technically is no "File" container
         klass = "Project" if klass == "File"
-        
+
         # Try to match an id (regardless of whether it'll be valid)
         record  = ref[-1].to_i
         project = if record > 0
@@ -37,7 +37,7 @@ module RedmineObjectStorage
         end
 
         filename = request.env["QUERY_STRING"].scan(/filename=(.*)/).flatten.first
-        path = Attachment.objectstorage_absolute_path(filename, project)
+        path = Attachment.objectstorage_absolute_path(filename)
 
         Attachment.set_context :class => klass, :project => project
         skip_redirection = true
@@ -49,7 +49,7 @@ module RedmineObjectStorage
         end
       end
 
-      path ||= @attachment.objectstorage_path
+      path ||= @attachment.objectstorage_filename
 
       expire_str = Attachment.objectstorage_config["expire"]
       expire = expire_str ? Integer(expire_str) : 86400


### PR DESCRIPTION
This plugin has a bug in it where attachments don't work on an issue when the issue is moved from one project to another.

This is because the attachments are stored in per-project directories in S3.

To simplify things, this pull request removes the project directory from the path when saving, reading, and deleting attachments.